### PR TITLE
Silence stdout noise during tests

### DIFF
--- a/stubserver/webserver.py
+++ b/stubserver/webserver.py
@@ -34,7 +34,6 @@ class StoppableHTTPServer(BaseHTTPServer.HTTPServer):
 
 if sys.version_info[0] == 2 and sys.version_info[1] < 6:
     HTTPServer = StoppableHTTPServer
-    print "Using stoppable server"
 else:
     HTTPServer = BaseHTTPServer.HTTPServer
 
@@ -145,8 +144,9 @@ class StubResponse(BaseHTTPServer.BaseHTTPRequestHandler):
                 self.wfile.write(exp.response[2])
                 data = self._get_data()
                 exp.satisfied = True
-                print "Captured data " + data
                 exp.data_capture["body"] = data
                 break
         self.wfile.flush()
 
+    def log_request(code=None, size=None):
+        pass


### PR DESCRIPTION
stubserver is quite noisy during tests, obscuring the usual test progress indicator. This patch removes the calls to `print` and also overrides the `log_request` method on the `BaseHTTPRequestHandler`, replacing it with a no-op.
