### PR TITLE
Configurable FTP timeout

### DIFF
--- a/stubserver/ftpserver.py
+++ b/stubserver/ftpserver.py
@@ -123,9 +123,9 @@ class FTPStubServer(object):
     def add_file(self, name, content):
         self._files[name] = content
         
-    def run(self):
+    def run(self, timeout = 2):
         self.server = SocketServer.TCPServer(('localhost',self.port), FTPServer(self.port, self._interactions, self._files))
-        self.server.timeout = 2
+        self.server.timeout = timeout
         self.server_thread = threading.Thread(target=self._run)
         self.server_thread.setDaemon(True)
         self.server_thread.start()


### PR DESCRIPTION
Hello,

I'm writing some tests for an FTP parser for work that has to be able to connect to mirrored FTP sites, unfortunately the default timeout on this module is making this a bit hard. 

Any chance of including the patch and releasing a new version?

Cheers,
Alex

PS. Cheers for this, saved me a boat load of time!
