### PR TITLE
allow_reuse_address required to not tie up socket.

### DIFF
--- a/stubserver/ftpserver.py
+++ b/stubserver/ftpserver.py
@@ -42,6 +42,7 @@ class FTPServer(SocketServer.BaseRequestHandler):
         self.data_handler = FTPDataServer(self.interactions, self.files)
         def start_data_server():
             self.port = self.port + 1
+            SocketServer.TCPServer.allow_reuse_address = True
             data_server = SocketServer.TCPServer(('localhost',self.port + 1), self.data_handler)
             data_server.handle_request()
             data_server.server_close()


### PR DESCRIPTION
This probably isn't the full scale fix, but it's a quick and dirty fix that worked for us. Was getting "this address is already in use" errors when running several tests in quick succession, looks like it's a TCP WAIT problem..
