### PR TITLE
Fixed StubServer issues and add a hostname parameter.

### DIFF
--- a/stubserver/ftpserver.py
+++ b/stubserver/ftpserver.py
@@ -1,24 +1,26 @@
-import threading, time
+import threading
+import time
 import SocketServer
 
+
 class FTPServer(SocketServer.BaseRequestHandler):
-   
-    def __init__(self, port, interactions, files):
+    def __init__(self, hostname, port, interactions, files):
+        self.hostname = hostname
         self.port = port
         self.interactions = interactions
         self.files = files
-   
+
     def __call__(self, request, client_address, server):
         self.request = request
         self.client_address = client_address
         self.server = server
         self.setup()
         try:
-           self.handle()
+            self.handle()
         finally:
-           self.finish()
+            self.finish()
         return self
-   
+
     def handle(self):
         # Establish connection
         self.request.send('220 (FtpStubServer 0.1a)\r\n')
@@ -28,35 +30,37 @@ class FTPServer(SocketServer.BaseRequestHandler):
             if cmd:
                 self.interactions.append(cmd)
                 getattr(self, '_' + cmd[:4])(cmd)
-   
+
     def _USER(self, cmd):
         self.request.send('331 Please specify password.\r\n')
-   
+
     def _PASS(self, cmd):
         self.request.send('230 You are now logged in.\r\n')
-   
+
     def _TYPE(self, cmd):
         self.request.send('200 Switching to ascii mode.\r\n')
-   
+
     def _PASV(self, cmd):
         self.data_handler = FTPDataServer(self.interactions, self.files)
+
         def start_data_server():
             self.port = self.port + 1
             SocketServer.TCPServer.allow_reuse_address = True
-            data_server = SocketServer.TCPServer(('localhost',self.port + 1), self.data_handler)
+            data_server = SocketServer.TCPServer((self.hostname, self.port + 1), self.data_handler)
             data_server.handle_request()
             data_server.server_close()
         self.t2 = threading.Thread(target=start_data_server)
         self.t2.start()
         time.sleep(0.1)
-        self.request.send('227 Entering Passive Mode. (127,0,0,1,%s,%s)\r\n' %(int((self.port + 1)/256), (self.port + 1) % 256))
+        self.request.send('227 Entering Passive Mode. (127,0,0,1,%s,%s)\r\n' % (
+            int((self.port + 1) / 256), (self.port + 1) % 256))
 
     def _STOR(self, cmd):
         self.request.send('150 Okay to send data\r\n')
         time.sleep(0.2)
         self.request.send('226 Got the file\r\n')
         self.t2.join(1)
-        
+
     def _LIST(self, cmd):
         self.request.send('150 Accepted data connection\r\n')
         time.sleep(0.2)
@@ -68,50 +72,55 @@ class FTPServer(SocketServer.BaseRequestHandler):
         time.sleep(0.2)
         self.request.send('226 Enjoy your file\r\n')
         self.t2.join(1)
-        
+
     def _QUIT(self, cmd):
         self.request.send('221 Goodbye\r\n')
         self.communicating = False
         time.sleep(0.001)
 
+
 class FTPDataServer(SocketServer.StreamRequestHandler):
-    
     def __init__(self, interactions, files):
         self.interactions = interactions
         self.files = files
         self.command = 'LIST'
-            
+
     def __call__(self, request, client_address, server):
         self.request = request
         self.client_address = client_address
         self.server = server
         self.setup()
         try:
-          self.handle()
-          return self
+            self.handle()
+            return self
         finally:
-          self.finish()
-        
+            self.finish()
+
     def handle(self):
         while not hasattr(self, '_' + self.interactions[-1:][0][:4]):
             time.sleep(0.01)
         getattr(self, '_' + self.interactions[-1:][0][:4])()
-        
+
     def filename(self):
         return self.interactions[-1:][0][5:].strip()
-        
+
     def _STOR(self):
         self.files[self.filename()] = self.rfile.read().strip()
-        
+
     def _LIST(self):
         self.wfile.write('\n'.join([name for name in self.files.keys()]))
-        
+
     def _RETR(self):
         self.wfile.write(self.files[self.filename()])
 
-class FTPStubServer(object):
 
-    def __init__(self, port):
+class ThreadedTCPServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer):
+    pass
+
+
+class FTPStubServer(object):
+    def __init__(self, port, hostname='localhost'):
+        self.hostname = hostname
         self.port = port
         self._interactions = []
         self._files = {}
@@ -120,23 +129,26 @@ class FTPStubServer(object):
         if name in self._files:
             return self._files[name]
         return None
-        
+
     def add_file(self, name, content):
         self._files[name] = content
-        
-    def run(self, timeout = 2):
-        self.server = SocketServer.TCPServer(('localhost',self.port), FTPServer(self.port, self._interactions, self._files))
-        self.server.timeout = timeout
-        self.server_thread = threading.Thread(target=self._run)
-        self.server_thread.setDaemon(True)
-        self.server_thread.start()
-   
-    def _run(self):
-        self.server.handle_request()
-        self.server.server_close()
-   
+
+    def run(self, timeout=2):
+        self.handler = FTPServer(self.hostname, self.port, self._interactions, self._files)
+        self.server = ThreadedTCPServer((self.hostname, self.port), self.handler)
+
+        # Retrieving actual port when using a random one.
+        if self.port == 0:
+            self.port = self.server.server_address[1]
+            self.handler.port = self.port
+
+        server_thread = threading.Thread(target=self.server.serve_forever)
+        # Exit the server thread when the main thread terminates
+        server_thread.daemon = True
+        server_thread.start()
+
     def stop(self):
-        self.server_thread.join()
+        self.server.shutdown()
         while self._interactions:
             self._interactions.pop()
         while self._files:


### PR DESCRIPTION
Rewrite FTPStubServer.run() threading strategy using example from Python doc
https://docs.python.org/2/library/socketserver.html#asynchronous-mixins
Manage random port attribution.
Fixed FTP tests.
some PEP8 here and there.

I wasn't able to have a running server instance on my machine. Port scan cannot found any TCP connection 
on the choosen port.
Using the asynchronous mixin from `SocketServer.ThreadingMixIn` solved the problem.
I also add the hostname parameter since proxies can be a pain in the arse with localhost hostname.