### PR TITLE
Fix mutation-while-iterating bug in StubServer

### DIFF
--- a/stubserver/webserver.py
+++ b/stubserver/webserver.py
@@ -73,7 +73,7 @@ class StubServer(object):
         for expectation in self._expectations:
             if not expectation.satisfied:
                 failures.append(str(expectation))
-            self._expectations.remove(expectation)
+        del self._expectations[:]
         if failures:
             raise Exception("Unsatisfied expectations: " + "\n".join(failures))
 

--- a/test.py
+++ b/test.py
@@ -141,7 +141,7 @@ class TestVerify(TestCase):
 
         self.server.verify()
 
-        self.assertItemsEqual([], self.server._expectations)
+        self.assertEqual([], self.server._expectations)
 
     def test_verify_checks_all_expectations(self):
         satisfied_expectation = self._MockExpectation(True)
@@ -152,8 +152,7 @@ class TestVerify(TestCase):
             satisfied_expectation
         ]
 
-        with self.assertRaises(Exception):
-            self.server.verify()
+        self.assertRaises(Exception, self.server.verify)
 
     class _MockExpectation(object):
         def __init__(self, satisfied):

--- a/test.py
+++ b/test.py
@@ -127,9 +127,20 @@ class FTPTest(TestCase):
         self.assertEquals(expected_content, '\n'.join(file_content))
 
 
-class TestVerify(TestCase):
+class VerifyTest(TestCase):
     def setUp(self):
         self.server = StubServer(8998)
+
+    def test_verify_checks_all_expectations(self):
+        satisfied_expectation = self._MockExpectation(True)
+        unsatisfied_expectation = self._MockExpectation(False)
+        self.server._expectations = [
+            satisfied_expectation,
+            unsatisfied_expectation,
+            satisfied_expectation
+        ]
+
+        self.assertRaises(Exception, self.server.verify)
 
     def test_verify_clears_all_expectations(self):
         satisfied_expectation = self._MockExpectation(True)
@@ -142,17 +153,6 @@ class TestVerify(TestCase):
         self.server.verify()
 
         self.assertEqual([], self.server._expectations)
-
-    def test_verify_checks_all_expectations(self):
-        satisfied_expectation = self._MockExpectation(True)
-        unsatisfied_expectation = self._MockExpectation(False)
-        self.server._expectations = [
-            satisfied_expectation,
-            unsatisfied_expectation,
-            satisfied_expectation
-        ]
-
-        self.assertRaises(Exception, self.server.verify)
 
     class _MockExpectation(object):
         def __init__(self, satisfied):

--- a/test.py
+++ b/test.py
@@ -127,5 +127,38 @@ class FTPTest(TestCase):
         self.assertEquals(expected_content, '\n'.join(file_content))
 
 
+class TestVerify(TestCase):
+    def setUp(self):
+        self.server = StubServer(8998)
+
+    def test_verify_clears_all_expectations(self):
+        satisfied_expectation = self._MockExpectation(True)
+        self.server._expectations = [
+            satisfied_expectation,
+            satisfied_expectation,
+            satisfied_expectation
+        ]
+
+        self.server.verify()
+
+        self.assertItemsEqual([], self.server._expectations)
+
+    def test_verify_checks_all_expectations(self):
+        satisfied_expectation = self._MockExpectation(True)
+        unsatisfied_expectation = self._MockExpectation(False)
+        self.server._expectations = [
+            satisfied_expectation,
+            unsatisfied_expectation,
+            satisfied_expectation
+        ]
+
+        with self.assertRaises(Exception):
+            self.server.verify()
+
+    class _MockExpectation(object):
+        def __init__(self, satisfied):
+            self.satisfied = satisfied
+
+
 if __name__=='__main__':
     unittest.main()


### PR DESCRIPTION
``self._expectations`` should be cleared outside of the loop in order to avoid the following issue:

```python
>>> letters = ['a', 'b', 'c']
>>> for letter in letters:
...     print(letter)
...     letters.remove(letter)
... 
a
c
>>> letters
['b']
```