### PR TITLE
remove mutable default value from expectation initialization

### DIFF
--- a/stubserver/webserver.py
+++ b/stubserver/webserver.py
@@ -77,7 +77,7 @@ class StubServer(object):
         if failures:
             raise Exception("Unsatisfied expectations: " + "\n".join(failures))
 
-    def expect(self, method="GET", url="^UrlRegExpMather$", data=None, data_capture={},
+    def expect(self, method="GET", url="^UrlRegExpMather$", data=None, data_capture=None,
                file_content=None):
         """
         Prepare :class:`StubServer` to handle an HTTP request.
@@ -121,6 +121,8 @@ class Expectation(object):
                              by server.
         :type data_capture: ``dict``
         """
+        if data_capture is None:
+            data_capture = {}
         self.method = method
         self.url = url
         self.data = data
@@ -162,7 +164,7 @@ class StubResponse(BaseHTTPServer.BaseHTTPRequestHandler):
         try:
             self.setup()
             self.handle()
-        finally:    
+        finally:
             self.finish()
 
     def __init__(self, expectations):

--- a/test.py
+++ b/test.py
@@ -55,6 +55,16 @@ class WebTest(TestCase):
         f, reply_code = self._make_request("http://localhost:8998/address/45/inhabitant", method="POST", payload='<inhabitant name="Chris"/>')
         self.assertEquals(204, reply_code)
 
+    def test_post_with_data_and_no_body_response(self):
+        self.server.expect(method="POST", url="address/\d+/inhabitant", data='Twas brillig and the slithy toves').and_return(reply_code=204)
+        f, reply_code = self._make_request("http://localhost:8998/address/45/inhabitant", method="POST", payload='Twas brillig and the slithy toves')
+        self.assertEquals(204, reply_code)
+        self.server.expect(method="GET", url="/monitor/server_status$").and_return(content="Four score and seven years ago", mime_type="text/html")
+        try:
+            self.server.stop()
+        except Exception as e:
+            self.assertEquals(-1, str(e).find('brillig'), str(e))
+
     def test_get_with_data(self):
         self.server.expect(method="GET", url="/monitor/server_status$").and_return(content="<html><body>Server is up</body></html>", mime_type="text/html")
         f, reply_code = self._make_request("http://localhost:8998/monitor/server_status", method="GET")


### PR DESCRIPTION
I saw a strange {"body": ... } in the error message as I was working on [pull request 13](https://github.com/tarttelin/Python-Stub-Server/pull/13).  It is caused by the mutable default value StubServer.expect(data_capture={}).  I have initialized it to an empty dict if it's not specified to avoid pollution of the data on subsequent calls.  I moved the initialization down to Expectation for easier unit testing going forward.  