### PR TITLE
Python 3 support, fix threading for FTP server, add LIST/NLST/CWD/PWD, tighten things up

### DIFF
--- a/stubserver/ftpserver.py
+++ b/stubserver/ftpserver.py
@@ -12,6 +12,7 @@ class FTPServer(SocketServer.BaseRequestHandler):
         self.port = port
         self.interactions = interactions
         self.files = files
+        self.cwd = '/'
 
     def __call__(self, request, client_address, server):
         self.request = request
@@ -30,10 +31,13 @@ class FTPServer(SocketServer.BaseRequestHandler):
         self.communicating = True
         while self.communicating:
             cmd = self.request.recv(1024)
+            if len(cmd) == 0:
+                break
             if cmd:
                 self.interactions.append(cmd)
-                cmd = cmd.decode('utf-8')
-                getattr(self, '_' + cmd[:4])(cmd)
+                cmd = cmd.decode('utf-8').rstrip()
+                first = cmd.split(' ', 1)[0]
+                getattr(self, '_' + first)(cmd)
 
     def _USER(self, cmd):
         self.request.send(b'331 Please specify password.\r\n')
@@ -45,23 +49,12 @@ class FTPServer(SocketServer.BaseRequestHandler):
         self.request.send(b'200 Switching to ascii mode.\r\n')
 
     def _PASV(self, cmd):
-        self.parent_event = threading.Event()
-        self.child_event = threading.Event()
-        self.data_handler = FTPDataServer(self.interactions, self.files, self.child_event)
+        self.data_handler = FTPDataServer(self.interactions, self.files)
+        self.port = self.port + 1
+        SocketServer.TCPServer.allow_reuse_address = True
+        self.data_server = SocketServer.TCPServer((self.hostname, self.port + 1), self.data_handler)
         
-        def start_data_server():
-            self.port = self.port + 1
-            SocketServer.TCPServer.allow_reuse_address = True
-            data_server = SocketServer.TCPServer((self.hostname, self.port + 1), self.data_handler)
-            # needs to signal ready here
-            self.parent_event.set()
-            data_server.handle_request()
-            data_server.server_close()
-            self.parent_event.set()
 
-        self.t2 = threading.Thread(target=start_data_server)
-        self.t2.start()
-        self.parent_event.wait()
         self.request.send(('227 Entering Passive Mode. (127,0,0,1,%s,%s)\r\n' % (
             int((self.port + 1) / 256), (self.port + 1) % 256)).encode('utf-8'))
 
@@ -69,40 +62,45 @@ class FTPServer(SocketServer.BaseRequestHandler):
         return self.interactions[-1:][0][5:].strip()
 
     def child_go(self):
-        self.child_event.set()
-        self.parent_event.clear()
-        self.parent_event.wait()
+        self.data_server.handle_request()
+        self.data_server.server_close()
 
     def _STOR(self, cmd):
         self.request.send(b'150 Okay to send data\r\n')
         self.child_go()
         self.request.send(b'226 Got the file\r\n')
-        self.t2.join(1)
 
     def _LIST(self, cmd):
         self.request.send(b'150 Accepted data connection\r\n')
         self.child_go()
         self.request.send(b'226 You got the listings now\r\n')
-        self.t2.join(1)
 
     def _RETR(self, cmd):
         self.request.send(b'150 Accepted data connection\r\n')
         self.child_go()
         self.request.send(b'226 Enjoy your file\r\n')
-        self.t2.join(1)
+
+    def _CWD(self, cmd):
+        self.cwd = cmd.split(' ',2)[1]
+        self.request.send(b'250 OK. Current directory is "%s"\r\n' % self.cwd.encode('utf-8'))
+
+    def _PWD(self, cmd):
+        self.request.send(b'257 "%s" is your current location\r\n' % self.cwd.encode('utf-8'))
+
+    def _NLST(self, cmd):
+        self.request.send(b'150 Accepted data connection\r\n')
+        self.child_go()
+        self.request.send(b'226 You got the listings now\r\n')
 
     def _QUIT(self, cmd):
-        self.request.send(b'221 Goodbye\r\n')
         self.communicating = False
-        time.sleep(0.001)
-
+        self.request.send(b'221-Goodbye.\r\n221 Have fun.')
 
 class FTPDataServer(SocketServer.StreamRequestHandler):
-    def __init__(self, interactions, files, event):
+    def __init__(self, interactions, files):
         self.interactions = interactions
         self.files = files
         self.command = 'LIST'
-        self.child_event = event
 
     def __call__(self, request, client_address, server):
         self.request = request
@@ -116,7 +114,6 @@ class FTPDataServer(SocketServer.StreamRequestHandler):
             self.finish()
 
     def handle(self):
-        self.child_event.wait()
         cmd = self.interactions[-1:][0].decode('utf-8')
         if cmd[:4] == 'PASV':
             return
@@ -131,11 +128,15 @@ class FTPDataServer(SocketServer.StreamRequestHandler):
         self.files[self.filename()] = self.rfile.read().strip()
 
     def _LIST(self):
-        data = '\n'.join([name for name in self.files.keys()])
-        self.wfile.write(data.encode('utf-8'))
+        data = b'\n'.join([name for name in self.files.keys()])
+        self.wfile.write(data)
+
+    def _NLST(self):
+        data = b'\015\012'.join([name for name in self.files.keys()])
+        self.wfile.write(data)
 
     def _RETR(self):
-        self.wfile.write(self.files[self.filename().decode('utf-8')].encode('utf-8'))
+        self.wfile.write(self.files[self.filename()])
 
 
 class ThreadedTCPServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer):

--- a/test.py
+++ b/test.py
@@ -36,7 +36,7 @@ class WebTest(TestCase):
         with open("./data.txt", "r") as f:
             expected = f.read().encode('utf-8')
         try:
-            self.assertEquals(expected, response.read())
+            self.assertEqual(expected, response.read())
         finally:
             response.close()
         
@@ -45,35 +45,35 @@ class WebTest(TestCase):
         self.server.expect(method="PUT", url="/address/\d+$", data_capture=capture).and_return(reply_code=201)
         f, reply_code = self._make_request("http://localhost:8998/address/45", method="PUT", payload=str({"hello": "world", "hi": "mum"}))
         try:
-            self.assertEquals(b"", f.read())
+            self.assertEqual(b"", f.read())
             captured = eval(capture["body"])
-            self.assertEquals("world", captured["hello"])
-            self.assertEquals("mum", captured["hi"])
-            self.assertEquals(201, reply_code)
+            self.assertEqual("world", captured["hello"])
+            self.assertEqual("mum", captured["hi"])
+            self.assertEqual(201, reply_code)
         finally:
             f.close()
 
     def test_post_with_data_and_no_body_response(self):
         self.server.expect(method="POST", url="address/\d+/inhabitant", data='<inhabitant name="Chris"/>').and_return(reply_code=204)
         f, reply_code = self._make_request("http://localhost:8998/address/45/inhabitant", method="POST", payload='<inhabitant name="Chris"/>')
-        self.assertEquals(204, reply_code)
+        self.assertEqual(204, reply_code)
 
     def test_post_with_data_and_no_body_response(self):
         self.server.expect(method="POST", url="address/\d+/inhabitant", data='Twas brillig and the slithy toves').and_return(reply_code=204)
         f, reply_code = self._make_request("http://localhost:8998/address/45/inhabitant", method="POST", payload='Twas brillig and the slithy toves')
-        self.assertEquals(204, reply_code)
+        self.assertEqual(204, reply_code)
         self.server.expect(method="GET", url="/monitor/server_status$").and_return(content="Four score and seven years ago", mime_type="text/html")
         try:
             self.server.stop()
         except Exception as e:
-            self.assertEquals(-1, str(e).find('brillig'), str(e))
+            self.assertEqual(-1, str(e).find('brillig'), str(e))
 
     def test_get_with_data(self):
         self.server.expect(method="GET", url="/monitor/server_status$").and_return(content="<html><body>Server is up</body></html>", mime_type="text/html")
         f, reply_code = self._make_request("http://localhost:8998/monitor/server_status", method="GET")
         try:
             self.assertTrue(b"Server is up" in f.read())
-            self.assertEquals(200, reply_code)
+            self.assertEqual(200, reply_code)
         finally:
             f.close()
 
@@ -82,7 +82,7 @@ class WebTest(TestCase):
         f, reply_code = self._make_request("http://localhost:8998/", method="GET")
         try:
             self.assertTrue(b"Server is up" in f.read())
-            self.assertEquals(200, reply_code)
+            self.assertEqual(200, reply_code)
         finally:
             f.close()
 
@@ -96,8 +96,8 @@ class WebTest(TestCase):
                                            payload='<inhabitant name="Chris"/>')
 
         # Validate the response
-        self.assertEquals("Method not allowed", f.msg)
-        self.assertEquals(405, reply_code)
+        self.assertEqual("Method not allowed", f.msg)
+        self.assertEqual(405, reply_code)
         self.assertTrue(f.read().startswith(b"Method PUT not allowed."))
 
         # And we have an unmet expectation which needs to mention the POST that didn't happen
@@ -108,7 +108,7 @@ class WebTest(TestCase):
 
     def test_unexpected_get(self):
         f, reply_code = self._make_request("http://localhost:8998/address/45/inhabitant", method="GET")
-        self.assertEquals(404, reply_code)
+        self.assertEqual(404, reply_code)
         self.server.stop()
 
     def test_repeated_get(self):
@@ -118,115 +118,88 @@ class WebTest(TestCase):
 
         for i in range(1, 4):
             f, reply_code = self._make_request("http://localhost:8998/counter", method="GET")
-            self.assertEquals(200, reply_code)
-            self.assertEquals(str(i).encode('utf-8'), f.read())
+            self.assertEqual(200, reply_code)
+            self.assertEqual(str(i).encode('utf-8'), f.read())
 
     def test_extra_get(self):
         self.server.expect(method="GET", url="counter$").and_return(content="1")
         f, reply_code = self._make_request("http://localhost:8998/counter", method="GET")
-        self.assertEquals(200, reply_code)
-        self.assertEquals(b"1", f.read())
+        self.assertEqual(200, reply_code)
+        self.assertEqual(b"1", f.read())
 
         f, reply_code = self._make_request("http://localhost:8998/counter", method="GET")
-        self.assertEquals(400, reply_code)
-        self.assertEquals("Expectations exhausted",f.msg)
+        self.assertEqual(400, reply_code)
+        self.assertEqual("Expectations exhausted",f.msg)
         self.assertTrue(f.read().startswith(b"Expectations at this URL have already been satisfied.\n"))
 
 
 class FTPTest(TestCase):
-    def setUp(self):
-        self.random_port = 0
-        self.server = FTPStubServer(self.random_port)
-        self.server.run()
-        self.port = self.server.server.server_address[1]
+    @classmethod
+    def setUpClass(cls):
+        FTPTest.server = FTPStubServer(0)
+        FTPTest.server.run()
+        FTPTest.port = FTPTest.server.server.server_address[1]
+        
+    @classmethod
+    def tearDownClass(cls):
+        FTPTest.server.stop()
 
+    def setUp(self):
+        self.ftp = FTP()
+        self.ftp.set_debuglevel(0)
+        self.ftp.connect('localhost', self.port)
+        self.ftp.login('user1', 'passwd')
+        
     def tearDown(self):
-        self.server.stop()
+        self.ftp.quit()
+        self.ftp.close()
 
     def test_change_directory(self):
-        ftp = FTP()
-        ftp.set_debuglevel(0)
-        ftp.connect('localhost', self.port)
-        ftp.login('user1', 'passwd')
-        ftp.cwd('newdir')
-        self.assertEqual(ftp.pwd(), 'newdir')
-        ftp.quit()
-        ftp.close()
+        self.ftp.cwd('newdir')
+        self.assertEqual(self.ftp.pwd(), 'newdir')
 
     def test_put_test_file(self):
         self.assertFalse(self.server.files("foo.txt"))
-        ftp = FTP()
-        ftp.set_debuglevel(0)
-        ftp.connect('localhost', self.port)
-        ftp.login('user1', 'passwd')
-
-        ftp.storlines('STOR foo.txt', BytesIO(b'cant believe its not bitter'))
-        ftp.quit()
-        ftp.close()
+        self.ftp.storlines('STOR foo.txt', BytesIO(b'cant believe its not bitter'))
         self.assertTrue(self.server.files("foo.txt"))
 
     def test_put_2_files_associates_the_correct_content_with_the_correct_filename(self):
-        ftp = FTP()
-        ftp.connect('localhost', self.port)
-        ftp.set_debuglevel(0)
-        ftp.login('user2','other_pass')
-
         data = "\n".join(["file1 content" for i in range(1024)])
-        ftp.storlines('STOR robot.txt', BytesIO(data.encode('utf-8')))
-        ftp.storlines('STOR monster.txt', BytesIO(b'file2 content'))
-        ftp.quit()
-        ftp.close()
-        self.assertEquals("\r\n".join(["file1 content" for i in range(1024)]),
+        self.ftp.storlines('STOR robot.txt', BytesIO(data.encode('utf-8')))
+        self.ftp.storlines('STOR monster.txt', BytesIO(b'file2 content'))
+        self.assertEqual("\r\n".join(["file1 content" for i in range(1024)]),
                           self.server.files("robot.txt").strip())
-        self.assertEquals("file2 content", self.server.files("monster.txt").strip())
+        self.assertEqual("file2 content", self.server.files("monster.txt").strip())
 
     def test_list_2_files(self):
-        ftp = FTP()
-        ftp.connect('localhost', self.port)
-        ftp.set_debuglevel(0)
-        ftp.login('user2','other_pass')
         self.lines = []
         def accumulate(line):
             self.lines.append(line)
 
-        ftp.storlines('STOR palladium.csv', BytesIO(b'data'))
-        ftp.storlines('STOR vanadiyam.pdf', BytesIO(b'more data'))
-        ftp.retrlines('LIST', accumulate)
-        self.assertEqual(self.lines, ['palladium.csv', 'vanadiyam.pdf'])
-        ftp.quit()
-        ftp.close()
+        self.ftp.storlines('STOR palladium.csv', BytesIO(b'data'))
+        self.ftp.storlines('STOR vanadiyam.pdf', BytesIO(b'more data'))
+        self.ftp.retrlines('LIST', accumulate)
+        self.assertEqual(sorted(self.lines), sorted(['vanadiyam.pdf', 'palladium.csv']))
 
     def test_nlst_2_files(self):
-        ftp = FTP()
-        ftp.connect('localhost', self.port)
-        ftp.set_debuglevel(0)
-        ftp.login('user2','other_pass')
         self.lines = []
         def accumulate(line):
             self.lines.append(line)
 
-        ftp.storlines('STOR palladium.csv', BytesIO(b'data'))
-        ftp.storlines('STOR vanadiyam.pdf', BytesIO(b'more data'))
-        ftp.retrlines('NLST', accumulate)
-        self.assertEqual(self.lines, ['palladium.csv', 'vanadiyam.pdf'])
-        ftp.quit()
-        ftp.close()
+        self.ftp.storlines('STOR palladium.csv', BytesIO(b'data'))
+        self.ftp.storlines('STOR vanadiyam.pdf', BytesIO(b'more data'))
+        self.ftp.retrlines('NLST', accumulate)
+        self.assertEqual(sorted(self.lines), sorted(['vanadiyam.pdf', 'palladium.csv']))
 
     def test_retrieve_expected_file_returns_file(self):
         expected_content = 'content of my file\nis a complete mystery to me.'
-        self.server.add_file(b'foo.txt', expected_content)
-        ftp = FTP()
-        ftp.set_debuglevel(2)
-        ftp.connect('localhost', self.port)
-        ftp.login('chris', 'tarttelin')
+        self.server.add_file('foo.txt', expected_content)
         directory_content = []
-        ftp.retrlines('LIST', lambda x: directory_content.append(x))
+        self.ftp.retrlines('LIST', lambda x: directory_content.append(x))
         file_content = []
-        ftp.retrlines('RETR foo.txt', lambda x: file_content.append(x))
-        ftp.quit()
-        ftp.close()
+        self.ftp.retrlines('RETR foo.txt', lambda x: file_content.append(x))
         self.assertTrue('foo.txt' in '\n'.join(directory_content))
-        self.assertEquals(expected_content, '\n'.join(file_content))
+        self.assertEqual(expected_content, '\n'.join(file_content))
 
 
 class VerifyTest(TestCase):

--- a/test.py
+++ b/test.py
@@ -134,17 +134,10 @@ class WebTest(TestCase):
 
 
 class FTPTest(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        FTPTest.server = FTPStubServer(0)
-        FTPTest.server.run()
-        FTPTest.port = FTPTest.server.server.server_address[1]
-        
-    @classmethod
-    def tearDownClass(cls):
-        FTPTest.server.stop()
-
     def setUp(self):
+        self.server = FTPStubServer(0)
+        self.server.run()
+        self.port = self.server.server.server_address[1]
         self.ftp = FTP()
         self.ftp.set_debuglevel(0)
         self.ftp.connect('localhost', self.port)
@@ -153,6 +146,7 @@ class FTPTest(TestCase):
     def tearDown(self):
         self.ftp.quit()
         self.ftp.close()
+        self.server.stop()
 
     def test_change_directory(self):
         self.ftp.cwd('newdir')


### PR DESCRIPTION
This should make the stub server work with both Python 2 and 3.

It also fixes problems caused by the FTP data server being lodged in a separate thread. It does this by removing the thread aspect and controlling the data server directly within the same thread. This should make the code cleaner and eliminate coordination issues.

LIST/NLST/CWD/PWD are added.