### PR TITLE
Always return binary-strings from _get_data()

### DIFF
--- a/stubserver/webserver.py
+++ b/stubserver/webserver.py
@@ -181,7 +181,7 @@ class StubResponse(BaseHTTPServer.BaseHTTPRequestHandler):
     def _get_data(self):
         max_chunk_size = 10 * 1024 * 1024
         if "content-length" not in self.headers:
-            return ""
+            return b''
         size_remaining = int(self.headers["content-length"])
         data = []
         while size_remaining:

--- a/test.py
+++ b/test.py
@@ -19,10 +19,13 @@ class WebTest(TestCase):
         self.server.stop()
         self.server.verify()  # this is redundant because stop includes verify
 
-    def _make_request(self, url, method="GET", payload="", headers={}):
+    def _make_request(self, url, method="GET", payload=None, headers={}):
         self.opener = OpenerDirector()
         self.opener.add_handler(HTTPHandler())
-        request = Request(url, headers=headers, data=payload.encode('utf-8'))
+        if payload is None:
+            request = Request(url, headers=headers)
+        else:
+            request = Request(url, headers=headers, data=payload.encode('utf-8'))
         request.get_method = lambda: method
         response = self.opener.open(request)
         response_code = getattr(response, 'code', -1)


### PR DESCRIPTION
Creating `GET`-requests with `python-requests` results in a request that does not have `Content-Length` header. This causes a crash with Python 3 on line [stubserver/webserver.py:210](https://github.com/tarttelin/Python-Stub-Server/blob/master/stubserver/webserver.py#L210) since the string returned by `_get_data()` was **not** binary.

This Pull Request fixes that bug by returning `b''` when `Content-Length` is missing. It also changes tests to create such requests when `payload` argument is not given.
