### PR TITLE
mkd command support

### DIFF
--- a/stubserver/ftpserver.py
+++ b/stubserver/ftpserver.py
@@ -88,6 +88,10 @@ class FTPServer(SocketServer.BaseRequestHandler):
     def _PWD(self, cmd):
         self.request.send(('257 "%s" is your current location\r\n' % self.cwd).encode('utf-8'))
 
+    def _MKD(self, cmd):
+        mkd = cmd.split(' ', 2)[1]
+        self.request.send(('257 "%s" folder created\r\n' % mkd).encode('utf-8'))
+
     def _NLST(self, cmd):
         self.request.send(b'150 Accepted data connection\r\n')
         self.child_go('NLST')

--- a/test.py
+++ b/test.py
@@ -178,6 +178,11 @@ class FTPTest(TestCase):
         self.ftp.cwd('newdir')
         self.assertEqual(self.ftp.pwd(), 'newdir')
 
+    def test_make_directory(self):
+        prev_dir = self.ftp.pwd()
+        self.ftp.mkd('newdir/newdir')
+        self.assertEqual(self.ftp.pwd(), prev_dir)
+
     def test_put_test_file(self):
         self.assertFalse(self.server.files("foo.txt"))
         self.ftp.storlines('STOR foo.txt', BytesIO(b'cant believe its not bitter'))


### PR DESCRIPTION
Dummy mkd command is required for completeness to test code that uses the command.