### PR TITLE
Add support for specifying additional header fields for the response.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   # - "2.5"  # No longer supported
   - "2.6"
   - "2.7"
-  - "3.2"
+  # - "3.2"  # Officially retired
   - "3.3"
   - "3.4"
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,7 @@ python:
   - "pypy"
 
 install:
-  # - pip install -r requirements.txt
-  # - pip install -r requirements-tests.txt
-  # - pip install -r requirements-docs.txt
-  - pip install coveralls 'coverage<4'
+  - pip install -r requirements-test.txt
 
 script:
   - coverage run --source=stubserver setup.py test

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+coverage<4
+coveralls
+requests


### PR DESCRIPTION
This adds support for additional headers in the response from the stub server, which is required in a use case I have.

Handling of header fields differs between urllib and urllib2, thus the tests for this use requests. I'd actually recommend switching all tests to use requests, it would remove a lot of boilerplate. 